### PR TITLE
adding initial implementation

### DIFF
--- a/build_addresses.py
+++ b/build_addresses.py
@@ -1,0 +1,8 @@
+import csv
+csvfile = open('addresses.csv')
+reader = csv.DictReader(csvfile)
+addresses = [row['FULLADDR'].upper() for row in reader]
+with open('addresses.js', 'w') as output:
+    output.write('var addresses = ')
+    output.write(str(addresses))
+    output.write(';')

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+  <script src="trie.js" type="text/javascript"></script>
+  <script src="addresses.js" type="text/javascript"></script>
+</head>
+<body>
+<label>Search for address:</label>
+<input id="addressSearch" type="text" list="addressList" onkeyup="keyup()"/>
+<datalist id="addressList"/>
+
+<script type="text/javascript">
+var trie = new Trie();
+
+var start = new Date();
+addresses.forEach(address => trie.add(address));
+var loadTime = new Date() - start;
+console.log('loading '+ addresses.length +' addresses took '+ loadTime +' ms');
+
+var dataList = document.getElementById("addressList");
+function keyup() {
+  dataList.innerHTML = "";
+  var searchTerm = document.getElementById("addressSearch").value;
+  var start = new Date();
+  var results = trie.autocomplete(searchTerm);
+  var loadTime = new Date() - start;
+  console.log('searching for '+ searchTerm +' took '+ loadTime +' ms to find '+ results.length +' addresses');
+  console.log(results.slice(-5));
+  buildDataList(results);
+}
+
+function buildDataList(results) {
+  // only grab the first 5
+  results.slice(0, 5).map(result => {
+    var option = document.createElement("option");
+    option.value = result;
+    dataList.appendChild(option);
+  });
+}
+</script>
+</body>
+</html>

--- a/trie.js
+++ b/trie.js
@@ -1,0 +1,59 @@
+function Node(value) {
+  this.value = value;
+  this.children = {};
+  this.isLeafNode = false;
+}
+
+function Trie() {
+  this.root = new Node(null);
+}
+
+Trie.prototype.add = function(word, node) {
+  if (!word) return;
+  node = node || this.root;
+  var char = word.charAt(0);
+  var child = node.children[char];
+  if (!child) {
+    child = new Node(char);
+    node.children[char] = child;
+  }
+  var remainder = word.substring(1);
+  if (remainder.length === 0) {
+    child.isLeafNode = true;
+  } else {
+    this.add(remainder, child);
+  }
+};
+
+Trie.prototype.autocomplete = function(prefix, node, stem, words) {
+  node = node || this.root;
+  stem = stem || "";
+  words = words || [];
+  prefix = prefix.toUpperCase();
+  var char = prefix.charAt(0);
+  var child = node.children[char];
+  if (child) {
+    var remainder = prefix.substring(1);
+    if (remainder.length > 0) {
+      this.autocomplete(remainder, child, stem.concat(char), words);
+    } else {
+      this.dfs(child, stem.concat(char), words);
+    }
+  }
+  return words;
+};
+
+// depth-first search traversal
+Trie.prototype.dfs = function(node, chars = "", words = []) {
+  if (node && node.children) {
+    if (node.isLeafNode) {
+      words.push(chars);
+    } else {
+      Object.keys(node.children).forEach(
+        function(char) {
+          this.dfs(node.children[char], chars.concat(char), words);
+        }.bind(this)
+      );
+    }
+  }
+};


### PR DESCRIPTION
Here's the basics of what I'm thinking.  

1. We'll have to load the addresses into the trie structure.  Currently I'm just downloading the csv then running a python script to create an array of addresses.

```
wget -O addresses.csv https://opendata.arcgis.com/datasets/b7956c8840554a25ae4e35d08b8c17a6_0.csv
python build_addresses.py
``` 
It takes ~1-2 seconds to load all of the addresses into the trie.  This is kind of slow so we should look into optimizing this.

2. We need to provide some cross browser compatible way to show autocomplete options in the dropdown.  I was initially thinking a [datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist) would work but my gut tells me there are better ways to do this.  @tungly Is there a list of browsers the city needs to support?
